### PR TITLE
Add enby,fun to _redirects

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -4,7 +4,7 @@
 
 # Hosted Redirects
 /kiya https://kiya.cat 301
-/krystal https:/enby.fun/ 301
+/krystal https://enby.fun/ 301
 
 #Internal
 /github https://github.com/SillyLittleTech


### PR DESCRIPTION
- Adds enby.fun to the list of redirects this replaces the outdated direct webmoth link to CF pages