### PR TITLE
Move donation graph below sidebar content on donate page

### DIFF
--- a/donate.html
+++ b/donate.html
@@ -117,21 +117,19 @@
         box-shadow: 0 6px 18px rgba(102, 126, 234, 0.28);
       }
 
-      .donor-graph {
-        display: block;
-        max-width: 380px;
-        width: 100%;
-        height: auto;
-        margin: 40px auto 0;
-        border-radius: 12px;
-      }
-
       .donate-content {
         display: grid;
         grid-template-columns: minmax(240px, 1fr) minmax(0, 2fr);
         gap: clamp(16px, 2.5vw, 28px);
         align-items: start;
         margin-top: 8px;
+      }
+
+      .donate-sidebar {
+        display: flex;
+        flex-direction: column;
+        gap: 20px;
+        min-width: 0;
       }
 
       .donate-iframe-wrapper {
@@ -171,13 +169,24 @@
         overflow-wrap: anywhere;
       }
 
+      .donor-graph {
+        display: block;
+        width: 100%;
+        max-width: min(380px, 100%);
+        height: auto;
+        margin: 0;
+        border-radius: 12px;
+      }
+
       @container (max-width: 760px) {
         .donate-content {
           grid-template-columns: 1fr;
         }
 
+        .donate-sidebar,
         .donate-iframe-wrapper,
-        .donation-info-box {
+        .donation-info-box,
+        .donor-graph {
           width: 100%;
         }
 
@@ -195,8 +204,10 @@
           grid-template-columns: 1fr;
         }
 
+        .donate-sidebar,
         .donate-iframe-wrapper,
-        .donation-info-box {
+        .donation-info-box,
+        .donor-graph {
           width: 100%;
         }
       }
@@ -316,20 +327,22 @@
         </div>
       </div>
       <div class="donate-content">
-        <aside class="donation-info-box" aria-label="How donations are used">
-          <p>Donations help fund our projects and server costs, including:</p>
-          <ul>
-            <li>Domain Registration</li>
-            <li>Web hosting</li>
-            <li>Development of new template kits</li>
-            <li>Administrative support (Like SSO for volunteers)</li>
-          </ul>
-        </aside>
-              <img
-        class="donor-graph"
-        src="https://graph.hcb.hackclub.com/sillylittletech"
-        alt="Donor graph for SillyLittleTech"
-      />
+        <div class="donate-sidebar">
+          <aside class="donation-info-box" aria-label="How donations are used">
+            <p>Donations help fund our projects and server costs, including:</p>
+            <ul>
+              <li>Domain Registration</li>
+              <li>Web hosting</li>
+              <li>Development of new template kits</li>
+              <li>Administrative support (Like SSO for volunteers)</li>
+            </ul>
+          </aside>
+          <img
+            class="donor-graph"
+            src="https://graph.hcb.hackclub.com/sillylittletech"
+            alt="Donor graph for SillyLittleTech"
+          />
+        </div>
         <div class="donate-iframe-wrapper">
           <iframe
             src="https://hcb.hackclub.com/donations/start/sillylittletech"
@@ -368,7 +381,9 @@
             ) {
               return globalThis.SLT.theme.detectSystem();
             }
-          } catch (e) { console.warn(e); }
+          } catch (e) {
+            console.warn(e);
+          }
 
           // Fallback: detect via prefers-color-scheme.
           try {
@@ -394,7 +409,9 @@
               globalThis.SLT.theme.applyTheme(theme);
               return;
             }
-          } catch (e) { console.warn(e); }
+          } catch (e) {
+            console.warn(e);
+          }
           document.documentElement.dataset.theme = theme;
         }
 
@@ -410,7 +427,9 @@
             } else if (mq.addListener) {
               mq.addListener(applySystemTheme);
             }
-          } catch (e) { console.warn(e); }
+          } catch (e) {
+            console.warn(e);
+          }
 
           var toggle = document.getElementById("themeToggle");
           if (!toggle) return;


### PR DESCRIPTION
### Motivation
- The donor graph should sit below the sidebar text (not inside or constrained by it) and render at an appropriate size across breakpoints.
- Prevent the graph from appearing visually squashed or awkwardly scaled when displayed next to the donation iframe.

### Description
- Introduced a new `.donate-sidebar` wrapper that groups the `.donation-info-box` and the `.donor-graph` into a single vertical column placed beside the donation iframe.
- Moved and adjusted `.donor-graph` CSS so it uses `width: 100%` with `max-width: min(380px, 100%)`, removed the previous top margin, and kept `height: auto` to avoid odd scaling.
- Updated responsive rules so `.donate-sidebar`, `.donor-graph`, `.donation-info-box`, and the iframe wrapper expand to full width when the layout stacks on small screens.
- Applied Prettier formatting to `donate.html` as part of the change.

### Testing
- Ran `npx prettier --check donate.html`, which passed for the modified file.
- Ran `npx prettier --write donate.html` to format the file, which completed successfully.
- Ran `npm run lint` (which runs `prettier --check .`), which reported failures due to pre-existing formatting issues in unrelated files (`apply.html`, `assetlab/slticon.icon/icon.json`, `brand.html`, `index.html`, `README.md`, `script.js`, `theme.js`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8b96a81708321a277c0023b013f4a)