### PR TITLE
Add Privacy Policy footer link and adjust timestamp workflow to output pp.json

### DIFF
--- a/.github/workflows/timestamp.yml
+++ b/.github/workflows/timestamp.yml
@@ -21,8 +21,7 @@ jobs:
 
     - name: Write pp.json
       run: |
-        mkdir -p build
-        echo "{\"lastUpdated\": \"${{ steps.set_date.outputs.date }}\"}" > build/pp.json
+        echo "{\"lastUpdated\": \"${{ steps.set_date.outputs.date }}\"}" > pp.json
 
     - name: Configure Git
       run: |
@@ -31,6 +30,6 @@ jobs:
 
     - name: Commit and push if changed
       run: |
-        git add build/pp.json
+        git add pp.json
         git diff --cached --quiet || git commit -m "chore: update Privacy Policy last updated timestamp [skip ci]"
         git push

--- a/includes/footer.html
+++ b/includes/footer.html
@@ -1,5 +1,5 @@
 <div class="footer-inner">
-  <a href="brand.html">Brand guidelines</a>
+  <a href="brand.html">Brand guidelines</a> · <a href="policy.html">Privacy Policy</a>
   <div class="footer-copyright">
     © 2026 SillyLittleTech.<br />
     Fiscally sponsored by The Hack Foundation (d.b.a. Hack Club), a 501(c)(3)


### PR DESCRIPTION
### Motivation

- Surface the Privacy Policy in the site footer for easier access and ensure the privacy timestamp workflow writes the policy timestamp file to the expected location.

### Description

- Add a `Privacy Policy` link next to `Brand guidelines` in `includes/footer.html` to expose `policy.html` from the site footer.
- Update the GitHub Actions workflow `/.github/workflows/timestamp.yml` to write `pp.json` at the repository root instead of `build/pp.json` and stage the same file with `git add pp.json` so the timestamp commit targets the correct path.

### Testing

- No automated tests were run for these content and workflow path changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d126b7af78832189e0ddcfd26d5d6c)