### PR TITLE
[Switch] : Change form tool from Web3Form to Okta Workflows.

### DIFF
--- a/apply.html
+++ b/apply.html
@@ -138,11 +138,11 @@
       </div>
 
       <form
-        action="https://api.web3forms.com/submit"
+        action="https://sillylittle.workflows.okta.com/api/flo/0f22e3856fa49280c3f04502059e7ad6/invoke"
         class="apply-form pageclip-form"
         method="post"
       >
-        <input type="hidden" name="access_key" value="bb1dbccf-9087-4eac-ae65-5e8f412c71df">
+       <!-- <input type="hidden" name="access_key" value="bb1dbccf-9087-4eac-ae65-5e8f412c71df"> -->
         <div class="form-group">
           <label for="name">Name *</label>
           <input type="text" id="name" name="name" required />
@@ -196,12 +196,11 @@
     </div>
 
    <!-- <script src="https://s.pageclip.co/v1/pageclip.js" charset="utf-8"></script> -->
-   <!-- Commenting Turnstile code because web3forms is picky (and we need a form engine), will maybe look for another if we get a lot of spam. [Since pageclip is a dead service]-->
-   <!-- <script
+      <script
       src="https://challenges.cloudflare.com/turnstile/v0/api.js"
       async
       defer
-    ></script> -->
+    ></script> 
     <script src="theme.js"></script>
     <script src="script.js"></script>
   </body>

--- a/policy.html
+++ b/policy.html
@@ -145,9 +145,9 @@ fetch('/pp.json')
           <li>
             <strong>Contact form details:</strong> When you submit the Contact
             Us form, we receive the name you provide, your email address, and
-            your message. The form routes through Web3Forms You can review its
+            your message. The form routes through OktaWorkflows You can review its
             practices in the
-            <a href="https://web3forms.com/privacy">Web3Forms Privacy Policy</a>.
+            <a href="https://www.okta.com/legal/privacy-policy/">Okta Privacy Policy</a>.
           </li>
           <li>
             <strong>Request and performance logs:</strong> Cloudflare Pages may
@@ -189,11 +189,6 @@ fetch('/pp.json')
           <li>
             <a href="https://developers.cloudflare.com/pages/platform/data-usage/"
               >Cloudflare Pages Data Usage</a
-            >
-          </li>
-          <li>
-            <a href="https://www.okta.com/legal/privacy-policy/"
-              >Okta Privacy Policy</a
             >
           </li>
         </ul>


### PR DESCRIPTION
In an attempt to centralise and minimise third-party data collection on our users, and maintain control of our data, 
We are replacing Web3Forms (originally a replacement to PageClip) with a custom OktaWorkflows script to collect and parse form data.