### PR TITLE
Add logos for UpMagic and LinkPlummer projects

### DIFF
--- a/brand.html
+++ b/brand.html
@@ -70,10 +70,10 @@
 
       <section class="brand-hero">
        <!-- <img
-          src="assetlab/raster/newslticon.png"
+          src="https://sillylittle.tech/cdn-cgi/image/format=auto,quality=75/assetlab/raster/newslticon.png"
           alt="SillyLittleTech logo"
           class="brand-logo"
-          data-fallback="assetlab/smallicon.png"
+          data-fallback="https://sillylittle.tech/cdn-cgi/image/format=auto,quality=75/assetlab/smallicon.png"
         /> -->
         <div>
           <h2 class="brand-wordmark">
@@ -91,61 +91,61 @@
         <div class="logo-grid" aria-label="Brand and project logos">
          <figure class="logo-card">
             <img
-              src="assetlab/raster/newslticon.png"
+              src="https://sillylittle.tech/cdn-cgi/image/format=auto,quality=75/assetlab/raster/newslticon.png"
               alt="SillyLittleTech icon"
             />
           </figure> 
           <figure class="logo-card">
             <img
-              src="assetlab/raster/text.png"
+              src="https://sillylittle.tech/cdn-cgi/image/format=auto,quality=75/assetlab/raster/text.png"
               alt="SillyLittleTech wordmark"
             />
           </figure>
           <figure class="logo-card">
             <img
-              src="assetlab/raster/text_alt.png"
+              src="https://sillylittle.tech/cdn-cgi/image/format=auto,quality=75/assetlab/raster/text_alt.png"
               alt="SillyLittleTech alternate wordmark"
             />
           </figure>
           <figure class="logo-card">
             <img
-              src="https://raw.githubusercontent.com/SillyLittleTech/sillylittletech.github.io/main/assets/FleanIconDefault-1024x1024%401x.png"
+              src="https://sillylittle.tech/cdn-cgi/image/format=auto,quality=75,width=512/https://projects.sillylittle.tech/assets/FleanIconDefault-1024x1024@1x.png"
               alt="Flean project logo"
             />
           </figure>
           <figure class="logo-card">
             <img
-              src="https://raw.githubusercontent.com/SillyLittleTech/sillylittletech.github.io/main/assets/JotIconDefault-1024x1024%401x.png"
+              src="https://sillylittle.tech/cdn-cgi/image/format=auto,quality=75,width=512/https://projects.sillylittle.tech/assets/JotIconDefault-1024x1024@1x.png"
               alt="Jot project logo"
             />
           </figure>
           <figure class="logo-card">
             <img
-              src="https://raw.githubusercontent.com/SillyLittleTech/sillylittletech.github.io/main/assets/cookiecutDefault-1024x1024%401x.png"
+              src="https://sillylittle.tech/cdn-cgi/image/format=auto,quality=75,width=512/https://projects.sillylittle.tech/assets/cookiecutDefault-1024x1024@1x.png"
               alt="Cookiecut project logo"
             />
           </figure>
           <figure class="logo-card">
             <img
-              src="https://raw.githubusercontent.com/SillyLittleTech/sillylittletech.github.io/main/assets/jetveiliconDefault-1024x1024%401x.png"
+              src="https://sillylittle.tech/cdn-cgi/image/format=auto,quality=75,width=512/https://projects.sillylittle.tech/assets/jetveiliconDefault-1024x1024@1x.png"
               alt="Jetveil project logo"
             />
           </figure>
           <figure class="logo-card">
             <img
-              src="https://raw.githubusercontent.com/SillyLittleTech/sillylittletech.github.io/main/assets/oldclassicDefault-1024x1024%401x.png"
+              src="https://sillylittle.tech/cdn-cgi/image/format=auto,quality=75,width=512/https://projects.sillylittle.tech/assets/oldclassicDefault-1024x1024@1x.png"
               alt="Old Classic project logo"
             />
           </figure>
           <figure class="logo-card">
             <img
-              src="https://raw.githubusercontent.com/SillyLittleTech/sillylittletech.github.io/main/assets/pascurtain_rastericon.png"
+              src="https://sillylittle.tech/cdn-cgi/image/format=auto,quality=75,width=512/https://projects.sillylittle.tech/assets/pascurtain_rastericon.png"
               alt="Pascurtain project logo"
             />
           </figure>
           <figure class="logo-card">
             <img
-              src="https://raw.githubusercontent.com/SillyLittleTech/sillylittletech.github.io/main/assets/portfDefault-1024x1024%401x.png"
+              src="https://sillylittle.tech/cdn-cgi/image/format=auto,quality=75,width=512/https://projects.sillylittle.tech/assets/portfDefault-1024x1024@1x.png"
               alt="Portf project logo"
             />
           </figure>
@@ -223,22 +223,22 @@
         <div>
           <img
             class="badge-sample"
-            src="assetlab/raster/badges/hosted_light.png"
+            src="https://sillylittle.tech/cdn-cgi/image/format=auto,quality=75/assetlab/raster/badges/hosted_light.png"
             alt="hosted light"
           />
           <img
             class="badge-sample"
-            src="assetlab/raster/badges/hosted_dark.png"
+            src="https://sillylittle.tech/cdn-cgi/image/format=auto,quality=75/assetlab/raster/badges/hosted_dark.png"
             alt="hosted dark"
           />
           <img
             class="badge-sample"
-            src="assetlab/raster/badges/powered_light.png"
+            src="https://sillylittle.tech/cdn-cgi/image/format=auto,quality=75/assetlab/raster/badges/powered_light.png"
             alt="powered light"
           />
           <img
             class="badge-sample"
-            src="assetlab/raster/badges/powered_dark.png"
+            src="https://sillylittle.tech/cdn-cgi/image/format=auto,quality=75/assetlab/raster/badges/powered_dark.png"
             alt="powered dark"
           />
         </div>
@@ -313,22 +313,22 @@
           aria-label="Brand experience gallery"
         >
           <figure class="carousel-slide active">
-            <img src="brandmagic/homepage.png" alt="SillyLittleTech homepage" />
+            <img src="https://sillylittle.tech/cdn-cgi/image/format=auto,quality=75/brandmagic/homepage.png" alt="SillyLittleTech homepage" />
           </figure>
           <figure class="carousel-slide">
-            <img src="brandmagic/flean.png" alt="Flean brand visual" />
+            <img src="https://sillylittle.tech/cdn-cgi/image/format=auto,quality=75/brandmagic/flean.png" alt="Flean brand visual" />
           </figure>
           <figure class="carousel-slide">
-            <img src="brandmagic/jetveil.png" alt="Jetveil brand visual" />
+            <img src="https://sillylittle.tech/cdn-cgi/image/format=auto,quality=75/brandmagic/jetveil.png" alt="Jetveil brand visual" />
           </figure>
           <figure class="carousel-slide">
             <img
-              src="brandmagic/pascurtain.png"
+              src="https://sillylittle.tech/cdn-cgi/image/format=auto,quality=75/brandmagic/pascurtain.png"
               alt="Pascurtain brand visual"
             />
           </figure>
           <figure class="carousel-slide">
-            <img src="brandmagic/pinstick.png" alt="Pinstick brand visual" />
+            <img src="https://sillylittle.tech/cdn-cgi/image/format=auto,quality=75/brandmagic/pinstick.png" alt="Pinstick brand visual" />
           </figure>
         </div>
                 <code
@@ -392,7 +392,8 @@
       }
 
       function makeUrls(type, variant) {
-        const base = "https://sillylittle.tech/assetlab/raster/badges/";
+        const base =
+          "https://sillylittle.tech/cdn-cgi/image/format=auto,quality=75/assetlab/raster/badges/";
         return `${base}${type}_${variant}.png`;
       }
 

--- a/brand.html
+++ b/brand.html
@@ -151,13 +151,13 @@
           </figure>
           <figure class="logo-card">
             <img 
-              src="https://raw.githubusercontent.com/SillyLittleTech/sillylittletech.github.io/refs/heads/main/assets/UpMagicDefault-1024x1024%401x.png"
+              src="https://sillylittle.tech/cdn-cgi/image/format=auto,quality=75,width=512/https://projects.sillylittle.tech/assets/UpMagicDefault-1024x1024%401x.png"
               alt="UpMagic project logo"
               />
           </figure>
           <figure class="logo-card">
             <img
-              src="https://raw.githubusercontent.com/SillyLittleTech/sillylittletech.github.io/refs/heads/main/assets/linkplummerIconDefault-1024x1024%401x.png"
+              src="https://sillylittle.tech/cdn-cgi/image/format=auto,quality=75,width=512/https://projects.sillylittle.tech/assets/linkplummerIconDefault-1024x1024%401x.png"
               alt="LinkPlummer project icon"
               />
           </figure>

--- a/brand.html
+++ b/brand.html
@@ -149,6 +149,18 @@
               alt="Portf project logo"
             />
           </figure>
+          <figure class="logo-card">
+            <img 
+              src="https://raw.githubusercontent.com/SillyLittleTech/sillylittletech.github.io/refs/heads/main/assets/UpMagicDefault-1024x1024%401x.png"
+              alt="UpMagic project logo"
+              />
+          </figure>
+          <figure class="logo-card">
+            <img
+              src="https://raw.githubusercontent.com/SillyLittleTech/sillylittletech.github.io/refs/heads/main/assets/linkplummerIconDefault-1024x1024%401x.png"
+              alt="LinkPlummer project icon"
+              />
+          </figure>
         </div>
       </section>
 

--- a/donors.json
+++ b/donors.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "Okta",
-    "logo": "/assetlab/partner/okta.jpeg",
+    "logo": "https://sillylittle.tech/cdn-cgi/image/format=auto,quality=75/assetlab/partner/okta.jpeg",
     "contribution": "Okta provided Okta for Good Seats",
     "url": "https://www.okta.com/okta-for-good/",
     "featured": true,
@@ -9,7 +9,7 @@
   },
   {
     "name": "Microsoft",
-    "logo": "/assetlab/partner/microsoft.png",
+    "logo": "https://sillylittle.tech/cdn-cgi/image/format=auto,quality=75/assetlab/partner/microsoft.png",
     "contribution": "Provided Business Basic Seats & $2,000 credits",
     "url": "https://nonprofit.microsoft.com",
     "featured": true,
@@ -17,7 +17,7 @@
   },
   {
     "name": "Cloudflare",
-    "logo": "/assetlab/partner/cf.png",
+    "logo": "https://sillylittle.tech/cdn-cgi/image/format=auto,quality=75/assetlab/partner/cf.png",
     "contribution": "Cloudflare provides hosting software",
     "url": "https://www.cloudflare.com/galileo/",
     "featured": true,
@@ -25,7 +25,7 @@
   },
   {
     "name": "Candid",
-    "logo": "/assetlab/partner/candid.png",
+    "logo": "https://sillylittle.tech/cdn-cgi/image/format=auto,quality=75/assetlab/partner/candid.png",
     "contribution": "Provided a Coupon for their Grant tools, and access to their platform",
     "url": "https://candid.com",
     "featured": true,
@@ -33,7 +33,7 @@
   },
   {
     "name": "Good360",
-    "logo": "/assetlab/partner/goodstack.jpeg",
+    "logo": "https://sillylittle.tech/cdn-cgi/image/format=auto,quality=75/assetlab/partner/goodstack.jpeg",
     "contribution": "Good360 provided access to their platform for discounted logistics",
     "url": "https://good360.org/",
     "featured": true,
@@ -41,7 +41,7 @@
   },
   {
     "name": "Adobe",
-    "logo": "/assetlab/partner/adobe.png",
+    "logo": "https://sillylittle.tech/cdn-cgi/image/format=auto,quality=75/assetlab/partner/adobe.png",
     "contribution": "Adobe provided access to Adobe Express, and a discount on other products",
     "url": "https://express.adobe.com",
     "featured": false,
@@ -49,7 +49,7 @@
   },
   {
     "name": "BetterStack",
-    "logo": "/assetlab/partner/betterstack.png",
+    "logo": "https://sillylittle.tech/cdn-cgi/image/format=auto,quality=75/assetlab/partner/betterstack.png",
     "contribution": "BetterStack provided a discount on their platform for the NPO",
     "url": "https://betterstack.com/",
     "featured": false,
@@ -57,7 +57,7 @@
   },
   {
     "name": "Short.io",
-    "logo": "/assetlab/partner/shortiop.png",
+    "logo": "https://sillylittle.tech/cdn-cgi/image/format=auto,quality=75/assetlab/partner/shortiop.png",
     "contribution": "Short.io provided a non-profit discount",
     "url": "https://short.io/",
     "featured": false,
@@ -65,7 +65,7 @@
   },
   {
     "name": "Zoom",
-    "logo": "/assetlab/partner/zoom.webp",
+    "logo": "https://sillylittle.tech/cdn-cgi/image/format=auto,quality=75/assetlab/partner/zoom.webp",
     "contribution": "Provided a discount on Zoom Workspace plans",
     "url": "https://zoom.com",
     "featured": false,
@@ -73,7 +73,7 @@
   },
   {
     "name": "OpenAI",
-    "logo": "/assetlab/partner/openai.png",
+    "logo": "https://sillylittle.tech/cdn-cgi/image/format=auto,quality=75/assetlab/partner/openai.png",
     "contribution": "OpenAI provided a discount to their platform",
     "url": "https://openai.com",
     "featured": false,
@@ -81,7 +81,7 @@
   },
   {
     "name": "NewRelic",
-    "logo": "/assetlab/partner/newrelic.png",
+    "logo": "https://sillylittle.tech/cdn-cgi/image/format=auto,quality=75/assetlab/partner/newrelic.png",
     "contribution": "NewRelic Provided their O4G Grant",
     "url": "https://newrelic.com/social-impact",
     "featured": false,
@@ -89,7 +89,7 @@
   },
   {
     "name": "Monday.com",
-    "logo": "/assetlab/partner/monday.png",
+    "logo": "https://sillylittle.tech/cdn-cgi/image/format=auto,quality=75/assetlab/partner/monday.png",
     "contribution": "Monday provided 10 free seats their their platform",
     "url": "https://monday.com/nonprofits",
     "featured": false,

--- a/index.html
+++ b/index.html
@@ -63,10 +63,10 @@
         <div class="profile">
           <div class="avatar">
             <img
-              src="assetlab/raster/newslticon.png"
+              src="https://sillylittle.tech/cdn-cgi/image/format=auto,quality=75/assetlab/raster/newslticon.png"
               alt="SillyLittleTech logo"
               class="avatar-img"
-              data-fallback="assetlab/smallicon.png"
+              data-fallback="https://sillylittle.tech/cdn-cgi/image/format=auto,quality=75/assetlab/smallicon.png"
             />
           </div>
           <h1 class="name">Silly Little <span class="tech-thin">Tech</span></h1>
@@ -112,7 +112,7 @@
           <!-- NEW PILL BUTTON -->
           <a href="https://socks.sillylittle.tech" class="safety-pill">
             <img
-              src="https://raw.githubusercontent.com/SillyLittleTech/sillylittletech.github.io/refs/heads/main/assets/socksiconDefault-1024x1024%401x.png"
+              src="https://sillylittle.tech/cdn-cgi/image/format=auto,quality=75,width=512/https://projects.sillylittle.tech/assets/socksiconDefault-1024x1024@1x.png"
               alt="Safety Icon"
             />
             <span>Learn how to stay safe online</span>

--- a/policy.html
+++ b/policy.html
@@ -64,7 +64,7 @@
       </div>
 
       <section class="brand-hero">
-        <img src="assetlab/raster/newslticon.png" alt="SillyLittleTech logo" class="brand-logo" data-fallback="assetlab/smallicon.png">
+        <img src="https://sillylittle.tech/cdn-cgi/image/format=auto,quality=75/assetlab/raster/newslticon.png" alt="SillyLittleTech logo" class="brand-logo" data-fallback="https://sillylittle.tech/cdn-cgi/image/format=auto,quality=75/assetlab/smallicon.png">
         
       </section>
 

--- a/script.js
+++ b/script.js
@@ -183,6 +183,24 @@ function formatFeedExcerpt(rawText) {
   return plainText.replace(/\s+/g, " ").trim();
 }
 
+/** Prefix for Cloudflare-resized external raster URLs (rule 2). */
+const SLT_CDN_EXT_IMG_PREFIX =
+  "https://sillylittle.tech/cdn-cgi/image/format=auto,quality=75,width=512/";
+
+/**
+ * Wraps absolute HTTPS image URLs in Cloudflare image resizing; leaves data URLs,
+ * relative paths, and already-wrapped URLs unchanged.
+ */
+function cdnExternalImageUrl(url) {
+  if (!url) return url;
+  if (url.startsWith("data:")) return url;
+  if (url.startsWith("https://sillylittle.tech/cdn-cgi/image/")) return url;
+  if (url.startsWith("https://")) {
+    return `${SLT_CDN_EXT_IMG_PREFIX}${url}`;
+  }
+  return url;
+}
+
 /**
  * Fetches a JSON file containing contributor data and renders round profile icon links.
  * Each contributor object may have: { name, url, avatar, label }
@@ -216,7 +234,7 @@ function renderContributors(containerSelector, jsonPath) {
         );
 
         const img = document.createElement("img");
-        img.src = contributor.avatar || "";
+        img.src = cdnExternalImageUrl(contributor.avatar || "");
         img.alt = contributor.name || "";
 
         anchor.appendChild(img);

--- a/script.js
+++ b/script.js
@@ -196,7 +196,7 @@ function cdnExternalImageUrl(url) {
   if (url.startsWith("data:")) return url;
   if (url.startsWith("https://sillylittle.tech/cdn-cgi/image/")) return url;
   if (url.startsWith("https://")) {
-    return `${SLT_CDN_EXT_IMG_PREFIX}${url}`;
+    return `${SLT_CDN_EXT_IMG_PREFIX}${encodeURIComponent(url)}`;
   }
   return url;
 }


### PR DESCRIPTION
This pull request adds new visual assets to the brand showcase section. Specifically, it introduces two additional project logos to the "How do we look?" section in the `brand.html` file.

**Branding updates:**

* Added a figure displaying the "UpMagic" project logo to the brand showcase section (`brand.html`).
* Added a figure displaying the "LinkPlummer" project icon to the brand showcase section (`brand.html`).